### PR TITLE
Fix detection of Namespace.so workers

### DIFF
--- a/nix/action.yml
+++ b/nix/action.yml
@@ -17,15 +17,22 @@ runs:
   using: "composite"
   steps:
 
+    - name: Figure out if we are running in a Namespace.so runner or not
+      shell: bash
+      run: |
+        if [ -n "$NSC_PROFILE_TAG" ]; then
+          echo "NAMESPACE_RUNNER=1" >> $GITHUB_ENV
+        fi
+        
     - name: namespacelabs/nscloud-cache-action cannot mkdir /nix so we do it manually
-      if: ${{ env.NSC_PROFILE_TAG }} != ''
+      if: env.NAMESPACE_RUNNER
       shell: bash
       run: |
         sudo mkdir /nix
         sudo chown $USER /nix
 
     - uses: namespacelabs/nscloud-cache-action@v1
-      if: ${{ env.NSC_PROFILE_TAG }} != ''
+      if: env.NAMESPACE_RUNNER
       with:
         path: /nix
 


### PR DESCRIPTION
It turns out, latest gha-actions cannot run on ubuntu-latest because it wants to install namespace.so specific stuff. This fixes it. 