### PR TITLE
Add caching for ELM_HOME

### DIFF
--- a/nix/action.yml
+++ b/nix/action.yml
@@ -64,7 +64,7 @@ runs:
       if: env.NAMESPACE_RUNNER
       shell: bash
       run: |
-        mkdir /nix/elm
+        mkdir -p /nix/elm
         echo "ELM_HOME=/nix/elm" >> $GITHUB_ENV
         
     - name: Build nix-shell

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -60,19 +60,8 @@ runs:
         echo ""
         echo "=== CPU Virtualization Support ==="
         grep -E 'vmx|svm' /proc/cpuinfo | head -1 | grep -oE 'vmx|svm' && echo "CPU supports virtualization" || echo "CPU does NOT support virtualization"
-
-    - name: Cache ELM_HOME
-      if: env.NAMESPACE_RUNNER
-      shell: bash
-      run: |
-        mkdir -p /nix/elm
-        echo "ELM_HOME=/nix/elm" >> $GITHUB_ENV
         
     - name: Build nix-shell
       shell: bash
-      run: |
-        echo "a"
-        echo $ELM_HOME
-        echo "b"
-        nix-shell --run "echo 'nix-shell successfully entered'"
+      run: nix-shell --run "echo 'nix-shell successfully entered'"
 

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -35,6 +35,7 @@ runs:
       if: env.NAMESPACE_RUNNER
       with:
         path: /nix
+        path: ~/.elm
 
     - uses: cachix/install-nix-action@v27
       with:

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -34,8 +34,9 @@ runs:
     - uses: namespacelabs/nscloud-cache-action@v1.2.13
       if: env.NAMESPACE_RUNNER
       with:
-        path: /nix
-        path: ~/.elm
+        path: |
+          /nix
+          ~/.elm
 
     - uses: cachix/install-nix-action@v27
       with:

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -69,5 +69,7 @@ runs:
         
     - name: Build nix-shell
       shell: bash
-      run: nix-shell --run "echo 'nix-shell successfully entered'"
+      run: |
+        echo $ELM_HOME
+        nix-shell --run "echo 'nix-shell successfully entered'"
 

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -60,6 +60,13 @@ runs:
         echo "=== CPU Virtualization Support ==="
         grep -E 'vmx|svm' /proc/cpuinfo | head -1 | grep -oE 'vmx|svm' && echo "CPU supports virtualization" || echo "CPU does NOT support virtualization"
 
+    - name: Cache ELM_HOME
+      if: env.NAMESPACE_RUNNER
+      shell: bash
+      run: |
+        mkdir /nix/elm
+        echo "ELM_HOME=/nix/elm" >> $GITHUB_ENV
+        
     - name: Build nix-shell
       shell: bash
       run: nix-shell --run "echo 'nix-shell successfully entered'"

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -61,7 +61,7 @@ runs:
         echo ""
         echo "=== CPU Virtualization Support ==="
         grep -E 'vmx|svm' /proc/cpuinfo | head -1 | grep -oE 'vmx|svm' && echo "CPU supports virtualization" || echo "CPU does NOT support virtualization"
-        
+
     - name: Build nix-shell
       shell: bash
       run: nix-shell --run "echo 'nix-shell successfully entered'"

--- a/nix/action.yml
+++ b/nix/action.yml
@@ -70,6 +70,8 @@ runs:
     - name: Build nix-shell
       shell: bash
       run: |
+        echo "a"
         echo $ELM_HOME
+        echo "b"
         nix-shell --run "echo 'nix-shell successfully entered'"
 


### PR DESCRIPTION
As Evan said in Elm Slack:

> I always recommend people to save ELM_HOME and use it
> for CI. On almost all builds, this means you can skip:
> 1. Talking to package.elm-lang.org
> 2. Talking to github.com
> No need to download the code for each package. No need
> to build it. In the rare event that you add a dependency to 
> your project, that would incur one request to (1) and (2).


And then in discourse: https://discourse.elm-lang.org/t/towards-more-reliable-ci/10503